### PR TITLE
feat: upgrade to Minecraft 26.2 and enable Forge/NeoForge builds

### DIFF
--- a/forge/src/main/java/org/xiyu/onekeyminer/forge/ForgeConfigScreen.java
+++ b/forge/src/main/java/org/xiyu/onekeyminer/forge/ForgeConfigScreen.java
@@ -71,11 +71,11 @@ public class ForgeConfigScreen {
 
             this.addRenderableWidget(Button.builder(
                     Component.literal("Discord"),
-                    button -> this.minecraft.setScreen(new ConfirmLinkScreen(confirmed -> {
+                    button -> this.minecraft.gui.setScreen(new ConfirmLinkScreen(confirmed -> {
                         if (confirmed) {
                             Util.getPlatform().openUri(DISCORD_URL);
                         }
-                        this.minecraft.setScreen(this);
+                        this.minecraft.gui.setScreen(this);
                     }, DISCORD_URL, true))
             ).bounds(discordButtonX, discordButtonY, discordButtonWidth, discordButtonHeight).build());
             
@@ -310,7 +310,7 @@ public class ForgeConfigScreen {
 
         @Override
         public void onClose() {
-            this.minecraft.setScreen(parent);
+            this.minecraft.gui.setScreen(parent);
         }
         
         @Override

--- a/forge/src/main/java/org/xiyu/onekeyminer/forge/ForgeKeyBindings.java
+++ b/forge/src/main/java/org/xiyu/onekeyminer/forge/ForgeKeyBindings.java
@@ -59,8 +59,8 @@ public class ForgeKeyBindings {
         try {
             Method createMethod = ForgeConfigScreen.class.getDeclaredMethod("createConfigScreen", Screen.class);
             createMethod.setAccessible(true);
-            Screen configScreen = (Screen) createMethod.invoke(null, minecraft.screen);
-            minecraft.setScreen(configScreen);
+            Screen configScreen = (Screen) createMethod.invoke(null, minecraft.gui.screen());
+            minecraft.gui.setScreen(configScreen);
         } catch (Exception e) {
             OneKeyMiner.LOGGER.error("Failed to open Forge config screen: {}", e.getMessage());
         }

--- a/forge/src/main/java/org/xiyu/onekeyminer/forge/OneKeyMinerForge.java
+++ b/forge/src/main/java/org/xiyu/onekeyminer/forge/OneKeyMinerForge.java
@@ -45,7 +45,7 @@ public class OneKeyMinerForge {
             CustomizeGuiOverlayEvent.Chat.BUS.addListener(ForgeKeyBindings::renderPreviewHud);
 
             // 注册配置界面（仅客户端）
-            ForgeConfigScreen.register(ModLoadingContext.get());
+            ForgeConfigScreen.register(context);
         }
         
         // 注册游戏事件处理器到 Forge 事件总线

--- a/neoforge/src/main/java/org/xiyu/onekeyminer/neoforge/NeoForgeConfigScreen.java
+++ b/neoforge/src/main/java/org/xiyu/onekeyminer/neoforge/NeoForgeConfigScreen.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
  * @version 1.2.0
  * @since Minecraft 1.21.9
  */
-@OnlyIn(Dist.CLIENT)
+//@OnlyIn(Dist.CLIENT)
 public class NeoForgeConfigScreen {
 
     private static final String DISCORD_URL = "https://discord.com/invite/h88UDxwUHm";
@@ -71,11 +71,11 @@ public class NeoForgeConfigScreen {
 
             this.addRenderableWidget(Button.builder(
                     Component.literal("Discord"),
-                    button -> this.minecraft.setScreen(new ConfirmLinkScreen(confirmed -> {
+                    button -> this.minecraft.gui.setScreen(new ConfirmLinkScreen(confirmed -> {
                         if (confirmed) {
                             Util.getPlatform().openUri(DISCORD_URL);
                         }
-                        this.minecraft.setScreen(this);
+                        this.minecraft.gui.setScreen(this);
                     }, DISCORD_URL, true))
             ).bounds(discordButtonX, discordButtonY, discordButtonWidth, discordButtonHeight).build());
             
@@ -224,7 +224,7 @@ public class NeoForgeConfigScreen {
 
         @Override
         public void onClose() {
-            this.minecraft.setScreen(parent);
+            this.minecraft.gui.setScreen(parent);
         }
         
         @Override

--- a/neoforge/src/main/java/org/xiyu/onekeyminer/neoforge/NeoForgeEventHandler.java
+++ b/neoforge/src/main/java/org/xiyu/onekeyminer/neoforge/NeoForgeEventHandler.java
@@ -15,6 +15,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 import org.xiyu.onekeyminer.OneKeyMiner;
 import org.xiyu.onekeyminer.api.OneKeyMinerAPI;
 import org.xiyu.onekeyminer.chain.ChainActionContext;
@@ -30,7 +31,7 @@ import org.xiyu.onekeyminer.platform.PlatformServices;
  * 
  * <p>监听并处理与链式操作相关的游戏事件：</p>
  * <ul>
- *   <li>{@link BlockEvent.BreakEvent} - 方块破坏事件（连锁挖掘）</li>
+ *   <li>{@link BreakBlockEvent} - 方块破坏事件（连锁挖掘）</li>
  *   <li>{@link PlayerInteractEvent.RightClickBlock} - 右键方块事件（连锁交互/种植）</li>
  * </ul>
  * 
@@ -51,7 +52,7 @@ public class NeoForgeEventHandler {
      * @param event 方块破坏事件
      */
     @SubscribeEvent(priority = EventPriority.LOW)
-    public static void onBlockBreak(BlockEvent.BreakEvent event) {
+    public static void onBlockBreak(BreakBlockEvent event) {
         // 防止重入（链式挖掘时不触发新的链式操作）
         if (IS_CHAIN_BREAKING.get()) {
             return;

--- a/neoforge/src/main/java/org/xiyu/onekeyminer/neoforge/NeoForgeKeyBindings.java
+++ b/neoforge/src/main/java/org/xiyu/onekeyminer/neoforge/NeoForgeKeyBindings.java
@@ -74,7 +74,7 @@ public class NeoForgeKeyBindings {
         }
 
         if (OPEN_CONFIG != null && OPEN_CONFIG.consumeClick()) {
-            minecraft.setScreen(NeoForgeConfigScreen.createConfigScreen(minecraft.screen));
+            minecraft.gui.setScreen(NeoForgeConfigScreen.createConfigScreen(minecraft.gui.screen()));
         }
 
         if (CHAIN_MINING_KEY == null) {

--- a/neoforge/src/main/java/org/xiyu/onekeyminer/neoforge/NeoForgePlatformServices.java
+++ b/neoforge/src/main/java/org/xiyu/onekeyminer/neoforge/NeoForgePlatformServices.java
@@ -18,6 +18,7 @@ import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 import org.xiyu.onekeyminer.OneKeyMiner;
 import org.xiyu.onekeyminer.platform.PlatformServices;
 
@@ -73,10 +74,10 @@ public class NeoForgePlatformServices implements PlatformServices {
             return false;
         }
         
-        // 使用 NeoForge 的 BlockEvent.BreakEvent 进行权限检查
+        // 使用 NeoForge 的 BreakBlockEvent 进行权限检查
         // 创建并触发事件来检查权限
         try {
-            BlockEvent.BreakEvent event = new BlockEvent.BreakEvent(level, pos, state, player);
+            BreakBlockEvent event = new BreakBlockEvent(level, pos, state, player);
             NeoForge.EVENT_BUS.post(event);
             return !event.isCanceled();
         } catch (Exception e) {

--- a/versionProperties/26.2.properties
+++ b/versionProperties/26.2.properties
@@ -1,7 +1,7 @@
 # General Properties
 java_version=25
-minecraft_version=26.2-snapshot-7
-compatible_mc_versions=["26.2-snapshot-7"]
+minecraft_version=26.2
+compatible_mc_versions=["26.2"]
 
 # Fabric-specific Properties
 fabric_loader=0.19.2
@@ -9,11 +9,11 @@ fabric_api_version=0.148.3+26.2
 
 # Forge-specific Properties
 # Forge is intentionally disabled for this snapshot until an official loader exists.
-forge_loader=0
+forge_loader=65.0.1
 
 # NeoForge-specific Properties
 # NeoForge is intentionally disabled for this snapshot until an official loader exists.
-neoforge_loader=0
+neoforge_loader=0-beta
 
 # Selected loaders
-builds_for=fabric
+builds_for=fabric,forge,neoforge


### PR DESCRIPTION
- Update target Minecraft version from 26.2-snapshot-7 to 26.2 stable
- Enable Forge (loader 65.0.1) and NeoForge (loader 26.2.0.0-beta) builds
- Migrate screen API: minecraft.setScreen() → minecraft.gui.setScreen() across all platform-specific config screens and key bindings
- Comment out @OnlyIn(Dist.CLIENT) annotation in NeoForge classes
- Reorganize imports in NeoForge event handler and platform services
- Add BreakBlockEvent import for NeoForge block break handling