### PR TITLE
fix: replace @Redirect with MixinExtras @WrapOperation for carpet com…

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -26,11 +26,12 @@ if (gradle.ext.minecraft_version == "1.21.11") {
 }
 
 repositories {
-
+    mavenCentral()
 }
 
 dependencies {
     compileOnly "org.spongepowered:mixin:0.8.7"
+    compileOnly "io.github.llamalad7:mixinextras-common:0.5.4"
     testImplementation "org.junit.jupiter:junit-jupiter:5.12.2"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.12.2"
 }

--- a/common/src/main/java/org/xiyu/onekeyminer/chain/ServerUseBridge.java
+++ b/common/src/main/java/org/xiyu/onekeyminer/chain/ServerUseBridge.java
@@ -52,7 +52,8 @@ public final class ServerUseBridge {
 
     public static InteractionResult useOn(
             ItemStack item,
-            UseOnContext context
+            UseOnContext context,
+            Supplier<InteractionResult> originalUse
     ) {
         Player player = context.getPlayer();
         BlockHitResult hitResult = new BlockHitResult(
@@ -62,7 +63,7 @@ public final class ServerUseBridge {
                 context.isInside()
         );
         if (!(player instanceof ServerPlayer serverPlayer)) {
-            return item.useOn(context);
+            return originalUse.get();
         }
         return runBlockUse(
                 serverPlayer,
@@ -70,7 +71,7 @@ public final class ServerUseBridge {
                 item,
                 context.getHand(),
                 hitResult,
-                () -> item.useOn(context)
+                originalUse
         );
     }
 
@@ -80,10 +81,11 @@ public final class ServerUseBridge {
             Level level,
             Player player,
             InteractionHand hand,
-            BlockHitResult hitResult
+            BlockHitResult hitResult,
+            Supplier<InteractionResult> originalUse
     ) {
         if (!(player instanceof ServerPlayer serverPlayer)) {
-            return state.useItemOn(item, level, player, hand, hitResult);
+            return originalUse.get();
         }
         return runBlockUse(
                 serverPlayer,
@@ -91,13 +93,7 @@ public final class ServerUseBridge {
                 item,
                 hand,
                 hitResult,
-                () -> state.useItemOn(
-                        item,
-                        level,
-                        player,
-                        hand,
-                        hitResult
-                )
+                originalUse
         );
     }
 
@@ -128,14 +124,15 @@ public final class ServerUseBridge {
             Player player,
             Entity target,
             InteractionHand hand,
-            Vec3 location
+            Vec3 location,
+            Supplier<InteractionResult> originalUse
     ) {
         return runEntityUse(
                 player,
                 target,
                 hand,
                 player.getItemInHand(hand),
-                () -> target.interact(player, hand, location)
+                originalUse
         );
     }
 
@@ -143,14 +140,15 @@ public final class ServerUseBridge {
             ItemStack item,
             Player player,
             LivingEntity target,
-            InteractionHand hand
+            InteractionHand hand,
+            Supplier<InteractionResult> originalUse
     ) {
         return runEntityUse(
                 player,
                 target,
                 hand,
                 item,
-                () -> item.interactLivingEntity(player, target, hand)
+                originalUse
         );
     }
 

--- a/common/src/main/java/org/xiyu/onekeyminer/mixin/PlayerMixin.java
+++ b/common/src/main/java/org/xiyu/onekeyminer/mixin/PlayerMixin.java
@@ -1,5 +1,7 @@
 package org.xiyu.onekeyminer.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -9,13 +11,12 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.xiyu.onekeyminer.chain.ServerUseBridge;
 
 @Mixin(Player.class)
 abstract class PlayerMixin {
 
-    @Redirect(
+    @WrapOperation(
             method = "interactOn(Lnet/minecraft/world/entity/Entity;"
                     + "Lnet/minecraft/world/InteractionHand;"
                     + "Lnet/minecraft/world/phys/Vec3;)"
@@ -33,17 +34,19 @@ abstract class PlayerMixin {
             Entity target,
             Player player,
             InteractionHand hand,
-            Vec3 location
+            Vec3 location,
+            Operation<InteractionResult> original
     ) {
         return ServerUseBridge.interact(
                 player,
                 target,
                 hand,
-                location
+                location,
+                () -> original.call(target, player, hand, location)
         );
     }
 
-    @Redirect(
+    @WrapOperation(
             method = "interactOn(Lnet/minecraft/world/entity/Entity;"
                     + "Lnet/minecraft/world/InteractionHand;"
                     + "Lnet/minecraft/world/phys/Vec3;)"
@@ -62,13 +65,15 @@ abstract class PlayerMixin {
             ItemStack item,
             Player player,
             LivingEntity target,
-            InteractionHand hand
+            InteractionHand hand,
+            Operation<InteractionResult> original
     ) {
         return ServerUseBridge.interactLivingEntity(
                 item,
                 player,
                 target,
-                hand
+                hand,
+                () -> original.call(item, player, target, hand)
         );
     }
 }

--- a/common/src/main/java/org/xiyu/onekeyminer/mixin/ServerPlayerGameModeMixin.java
+++ b/common/src/main/java/org/xiyu/onekeyminer/mixin/ServerPlayerGameModeMixin.java
@@ -1,5 +1,7 @@
 package org.xiyu.onekeyminer.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.server.level.ServerPlayerGameMode;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionHand;
@@ -11,13 +13,12 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.xiyu.onekeyminer.chain.ServerUseBridge;
 
 @Mixin(ServerPlayerGameMode.class)
 abstract class ServerPlayerGameModeMixin {
 
-    @Redirect(
+    @WrapOperation(
             method = "useItemOn(Lnet/minecraft/server/level/ServerPlayer;"
                     + "Lnet/minecraft/world/level/Level;"
                     + "Lnet/minecraft/world/item/ItemStack;"
@@ -42,7 +43,8 @@ abstract class ServerPlayerGameModeMixin {
             Level level,
             Player player,
             InteractionHand hand,
-            BlockHitResult hitResult
+            BlockHitResult hitResult,
+            Operation<InteractionResult> original
     ) {
         return ServerUseBridge.useItemOnBlock(
                 state,
@@ -50,11 +52,12 @@ abstract class ServerPlayerGameModeMixin {
                 level,
                 player,
                 hand,
-                hitResult
+                hitResult,
+                () -> original.call(state, item, level, player, hand, hitResult)
         );
     }
 
-    @Redirect(
+    @WrapOperation(
             method = "useItemOn(Lnet/minecraft/server/level/ServerPlayer;"
                     + "Lnet/minecraft/world/level/Level;"
                     + "Lnet/minecraft/world/item/ItemStack;"
@@ -71,8 +74,13 @@ abstract class ServerPlayerGameModeMixin {
     )
     private InteractionResult onekeyminer$useOn(
             ItemStack item,
-            UseOnContext context
+            UseOnContext context,
+            Operation<InteractionResult> original
     ) {
-        return ServerUseBridge.useOn(item, context);
+        return ServerUseBridge.useOn(
+                item,
+                context,
+                () -> original.call(item, context)
+        );
     }
 }


### PR DESCRIPTION
## Problem

Running OneKeyMiner 26.2-1.6.9 (fabric) together with fabric-carpet 26.2 crashes the dedicated server at startup:

    @Redirect conflict. Skipping onekeyminer.mixins.json:ServerPlayerGameModeMixin
    -> @Redirect::onekeyminer$useItemOnBlock(...), already redirected by
    carpet.mixins.json:ServerPlayerGameMode_cactusMixin
    -> @Redirect::activateWithOptionalCactus(...)
    MixinTransformerError: ... (0/1) succeeded

## Root cause

Both mods @Redirect the same `BlockState.useItemOn` invocation inside `ServerPlayerGameMode.useItemOn`. Same default priority (1000), both mixins configs use `defaultRequire: 1` — the loser fails its injection check and the server aborts.

## Fix

Convert the four @Redirect hooks (ServerPlayerGameModeMixin x2, PlayerMixin x2) to MixinExtras `@WrapOperation`. The original invocation is forwarded as a `Supplier` into the existing `runBlockUse` / `runEntityUse` seams, so behaviour is unchanged. Wrap operations coexist with @Redirect: carpet keeps its cactus hook and chain mining keeps working. All four hooks are converted for consistency and to avoid the same conflict class with other mods.

## Changes

- `common/build.gradle`: compileOnly mixinextras-common 0.5.4 (runtime already provided by fabric-api, no new runtime dependency)
- `ServerUseBridge.java`: entry methods accept a `Supplier` for the original call
- Both mixin classes: @Redirect → @WrapOperation
- 4 files changed, +43 / -31

## Verification

- Dedicated fabric server, MC 26.2, loader 0.19.3
- Mods: fabric-carpet 26.2+v260616 + OneKeyMiner 1.6.9 (patched build) + 14 other mods
- Server boots cleanly: zero mixin conflicts, `Test passed`, both mods initialise normally

（由 deepseek 辅助修改）
